### PR TITLE
Fix cmd/gameoflife to use gameoflife.Rule instead of wireworld.Rule

### DIFF
--- a/cmd/gameoflife/gameoflife.go
+++ b/cmd/gameoflife/gameoflife.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/nsf/termbox-go"
 	"github.com/pierrre/cellauto"
-	"github.com/pierrre/cellauto/wireworld"
+	"github.com/pierrre/cellauto/gameoflife"
 	"github.com/pierrre/go-libs/goroutine"
 )
 
@@ -27,7 +27,7 @@ func main() {
 	width, height := termbox.Size()
 
 	game := &cellauto.Game{
-		Rule: wireworld.Rule,
+		Rule: gameoflife.Rule,
 		Grid: cellauto.NewGrid(cellauto.Point{X: width, Y: height}),
 	}
 	for y := range game.Grid.Size.Y {


### PR DESCRIPTION
## Problem

`cmd/gameoflife` set `Rule: wireworld.Rule` while never importing the `gameoflife` package, so the "Game of Life" application actually ran Wireworld semantics on a 0/1 checkerboard grid instead of Conway's Game of Life (B3/S23).

## Fix

Use `gameoflife.Rule` (the actual B3/S23 rule from the `gameoflife` package) instead of `wireworld.Rule`.