### PR TITLE
improve: add frame-rate cap to cmd/gameoflife render/step loop

### DIFF
--- a/cmd/gameoflife/gameoflife.go
+++ b/cmd/gameoflife/gameoflife.go
@@ -3,6 +3,7 @@ package main
 
 import (
 	"context"
+	"time"
 
 	"github.com/nsf/termbox-go"
 	"github.com/pierrre/cellauto"
@@ -64,5 +65,6 @@ func main() {
 		}
 
 		game.Step(ctx)
+		time.Sleep(time.Second / 30)
 	}
 }


### PR DESCRIPTION
The render/step loop in `cmd/gameoflife` had no sleep or frame-rate cap, busy-spinning and pegging one CPU core.

Add `time.Sleep(time.Second / 30)` at the end of the loop to cap the frame rate at ~30 FPS, preventing unnecessary CPU usage while maintaining smooth visualization.

Refs: cmd/gameoflife/gameoflife.go:41